### PR TITLE
Create .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+*
+
+!/lib
+!/README*
+!/LICENSE*
+!/package*


### PR DESCRIPTION
This package on npm is currently about **220 MB** large. This is because the e. g. the `docs` is included in the npm bundle, which contributes most of the 220 MB. Thus, npm and each developer has to download and store this on disk, which is not necessary.

This adds a `.npmignore` to exclude all files except

```gitignore
*

!/lib
!/README*
!/LICENSE*
!/package*
```

from the npm package.

See https://npm.github.io/publishing-pkgs-docs/publishing/the-npmignore-file.html

This should lower the package significantly.

Please consider merging this PR and releasing a new version on npm.